### PR TITLE
feat: Implement SAML/OIDC SSO and SCIM 2.0 PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,276 @@
-# task
+# Next.js Multi-Authentication Example App
+
+This Next.js application demonstrates implementations of SAML, OIDC (with Okta via NextAuth.js), and SCIM 2.0 provisioning endpoints.
+
+## General Setup
+
+1.  **Clone the repository.**
+2.  **Navigate to the application directory:**
+    ```bash
+    cd my-next-app
+    ```
+3.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+4.  **Environment Variables:** Some authentication methods require environment variables. Copy the `.env.local.example` file (if one exists, otherwise create `.env.local`) and populate it as per the instructions in the relevant sections below.
+5.  **Run the development server:**
+    ```bash
+    npm run dev
+    ```
+    The application will typically be available at `http://localhost:3000`.
+
+**Note on URL Paths and Locales:** This application uses a `[locale]` structure (e.g., `/en/...`, `/fr/...`). For simplicity, most URLs in this README are shown without a locale prefix (e.g., `/login/saml`). Depending on your setup and default locale, you may need to include a locale prefix in the path (e.g., `http://localhost:3000/en/login/saml`).
+
+---
+
+## SAML Configuration (using `passport-saml`)
+
+This section details how to set up SAML Single Sign-On.
+
+## SAML Configuration
+
+To enable SAML authentication, you need to configure your Identity Provider (IdP) and update the application with your IdP's details.
+
+### Service Provider (SP) Details
+
+Your application (the Service Provider) exposes the following SAML endpoints:
+
+-   **Assertion Consumer Service (ACS) URL:** `http://localhost:3000/api/auth/saml`
+    *   This is the URL your IdP will send SAML assertions to.
+-   **SP Metadata URL:** `http://localhost:3000/api/auth/saml/metadata`
+    *   This URL provides the SP metadata XML, which you might need to upload or provide to your IdP. It includes the SP's entity ID, ACS URL, and any public certificates for signing or encryption (if configured).
+-   **SP Entity ID (Issuer):** `http://localhost:3000/api/auth/saml/metadata` (This is also the metadata URL by default in this setup)
+
+### Identity Provider (IdP) Configuration
+
+Configuration requires updating placeholders directly in the SAML strategy code. These are found in:
+*   `my-next-app/src/app/api/auth/saml/route.ts` (for ACS)
+*   `my-next-app/src/app/api/auth/saml/login/route.ts` (for login initiation)
+*   `my-next-app/src/app/api/auth/saml/metadata/route.ts` (for metadata generation)
+
+**Specifically, update these placeholders:**
+
+1.  `REPLACE_WITH_IDP_LOGIN_URL`: This is the Single Sign-On (SSO) URL of your IdP where the application will redirect users for authentication.
+2.  `REPLACE_WITH_IDP_PUBLIC_CERTIFICATE`: This is the public X.509 certificate of your IdP, used by the application to verify the signature of SAML assertions. It should be the content of the certificate file, often in PEM format.
+3.  `REPLACE_WITH_IDP_ISSUER_URL`: This is the entity ID or issuer URL of your IdP.
+
+These values are typically found in your IdP's metadata file.
+
+### Setting up Okta as a SAML IdP (Example)
+
+1.  **In your Okta Developer Console:**
+    *   Navigate to **Applications** > **Applications**.
+    *   Click **Create App Integration**.
+    *   Select **SAML 2.0** as the sign-in method. Click **Next**.
+    *   **App name:** Give it a name (e.g., "My Next.js SAML App"). Click **Next**.
+
+2.  **Configure SAML Settings:**
+    *   **Single sign on URL (ACS URL):** `http://localhost:3000/api/auth/saml`
+    *   **Audience URI (SP Entity ID):** `http://localhost:3000/api/auth/saml/metadata` (Matches our SP metadata URL/issuer)
+    *   **Default RelayState:** Leave blank or as needed.
+    *   **Name ID format:** Select `EmailAddress` or as appropriate for your application.
+    *   **Application username:** Select `Email` or as appropriate.
+    *   *(Optional)* Configure attribute statements if your application requires them.
+    *   Click **Next**.
+
+3.  **Feedback:** Select "I'm an Okta customer adding an internal app". Click **Finish**.
+
+4.  **Obtain IdP Details:**
+    *   After the app is created, you'll be on its "Sign On" tab.
+    *   Look for a link or button like "**View SAML setup instructions**" or "**Identity Provider metadata**". Click it.
+    *   From the provided information or metadata XML, you will find:
+        *   **Identity Provider Single Sign-On URL:** This is your `REPLACE_WITH_IDP_LOGIN_URL` (for the `entryPoint` option in the SAML strategy).
+        *   **Identity Provider Issuer:** This is your `REPLACE_WITH_IDP_ISSUER_URL` (for the `idpIssuer` option, though `passport-saml` often uses `issuer` for the SP and gets IdP issuer from metadata or `entryPoint`). Ensure the `issuer` in the strategy refers to *our* SP Entity ID. The IdP's issuer will be verified from the SAML assertion. The `idpIssuer` field in the strategy config can be used for this.
+        *   **X.509 Certificate:** Download or copy the certificate. This is your `REPLACE_WITH_IDP_PUBLIC_CERTIFICATE`. Ensure it's the full certificate string, including `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
+
+5.  **Update Application Code:**
+    *   Place the obtained values into the corresponding placeholders in the SAML strategy configuration files mentioned above.
+
+### Example IdP Metadata XML (Generic)
+
+Below is an example of what an IdP's metadata XML might look like. You will get a similar file from your SAML Identity Provider. You need to extract the `SingleSignOnService` URL (for `entryPoint`), the `X509Certificate` (for `cert`), and the `entityID` of the `EntityDescriptor` (for `idpIssuer`).
+
+**This is only an example. DO NOT use it directly. Obtain the metadata from your actual IdP.**
+
+```xml
+<EntityDescriptor entityID="REPLACE_WITH_IDP_ISSUER_URL" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+  <IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>
+-----BEGIN CERTIFICATE-----
+MIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADCBhjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCkNhbGlmb3JuaWExFDASBgNVBAcMC1NhbiBGcmFuY2lzY28xGTAX
+BgNVBAoMEEV4YW1wbGUgT3JnYW5pY2UxGDAWBgNVBAsMD0V4YW1wbGUgSWRQIERl
+... more certificate data ...
+dHpDOVFnS3hqb01jVUR2c3R6Q1YrakZ0eWJ3PT0K
+-----END CERTIFICATE-----
+          </X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="REPLACE_WITH_IDP_LOGIN_URL_POST_BINDING"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="REPLACE_WITH_IDP_LOGIN_URL_REDIRECT_BINDING"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>
+```
+
+**Instructions for placeholders in the code:**
+
+*   `idpEntryPoint`: Use the `Location` URL from one of the `SingleSignOnService` elements (usually the HTTP-Redirect one for login initiation).
+*   `idpCert`: Copy the content of the `X509Certificate` element, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers.
+*   `idpIssuer`: Use the `entityID` from the `EntityDescriptor` element.
+
+## Using SAML Authentication
+
+*   **Login:** Navigate to `/login/saml` (e.g., `http://localhost:3000/en/login/saml`).
+*   **SP Metadata:** Available at `/api/auth/saml/metadata`.
+*   **ACS Endpoint:** `/api/auth/saml` (handles POST requests from IdP).
+
+## Important Notes for SAML
+
+*   **Security:** Ensure that your IdP certificate (`idpCert`) is correctly configured. In a production environment, consider using environment variables or a secure secret management system for these sensitive details instead of hardcoding them.
+*   **HTTPS:** For production, SAML requires HTTPS for all communications. Ensure your application is served over HTTPS.
+*   **Session Management:** This example logs the SAML profile to the console. In a real application, you would implement session management (e.g., using cookies, JWTs) to keep the user logged in.
+*   **Error Handling:** Basic error handling is in place, but you may want to expand it for a production application.
+*   **Passport Initialization:** The Passport.js strategy initialization is currently done in each SAML-related route file for simplicity in this example. In a larger application, centralize this initialization (e.g., in a `lib/passport.ts` or similar that runs once during application startup).
+
+---
+
+## OIDC Authentication (NextAuth.js with Okta)
+
+This application also supports OIDC authentication using NextAuth.js, with Okta as the example provider.
+
+### OIDC Configuration (Okta Example)
+
+1.  **Set up an Okta Application:**
+    *   Log in to your Okta Developer Console.
+    *   Navigate to **Applications** > **Applications** and click **Create App Integration**.
+    *   Select **OIDC - OpenID Connect** as the sign-in method.
+    *   Select **Web Application** as the Application type. Click **Next**.
+    *   **App integration name:** Give your application a name (e.g., "My Next.js App").
+    *   **Grant type:** Ensure `Authorization Code` is checked. `Refresh Token` can also be enabled if needed.
+    *   **Sign-in redirect URIs:** Add `http://localhost:3000/api/auth/callback/okta`
+        *   This is the default callback URL NextAuth.js uses for providers. The `okta` part matches the provider ID.
+    *   **Sign-out redirect URIs:** Add `http://localhost:3000/login/oidc` (or your desired post-logout page).
+    *   **Assignments:** Assign the application to relevant users or groups.
+    *   Save the application.
+
+2.  **Obtain Okta Credentials:**
+    *   After creating the application, you will find the **Client ID** and **Client secret** on the application's **General** tab.
+    *   You will also need your Okta **Issuer URI**. This is typically found under **Security** > **API** in your Okta dashboard (e.g., `https://your-okta-domain.okta.com/oauth2/default`). Make sure it's the issuer for the authorization server you intend to use (e.g., 'default' or a custom one).
+
+3.  **Configure Environment Variables:**
+    Create a `.env.local` file in the root of the `my-next-app` directory (if it doesn't exist) and add the following variables:
+    ```env
+    OKTA_OIDC_CLIENT_ID="YOUR_OKTA_CLIENT_ID"
+    OKTA_OIDC_CLIENT_SECRET="YOUR_OKTA_CLIENT_SECRET"
+    OKTA_OIDC_ISSUER="YOUR_OKTA_ISSUER_URI"
+
+    # Generate a random string for NEXTAUTH_SECRET (e.g., using `openssl rand -base64 32`)
+    NEXTAUTH_SECRET="YOUR_NEXTAUTH_SECRET"
+    NEXTAUTH_URL="http://localhost:3000" # Or your production URL in production
+    ```
+    *   Replace `YOUR_OKTA_CLIENT_ID`, `YOUR_OKTA_CLIENT_SECRET`, and `YOUR_OKTA_ISSUER_URI` with your actual Okta application credentials.
+    *   `NEXTAUTH_SECRET` is crucial for security in production. Generate a strong random string.
+    *   `NEXTAUTH_URL` should be the base URL of your Next.js application. For local development, this is `http://localhost:3000`.
+
+### Using OIDC Authentication
+
+*   **Login Page:** Navigate to `http://localhost:3000/login/oidc`. Click the "Sign in with Okta (OIDC)" button.
+*   **User Profile:** After successful authentication, you can view basic session information (including ID token and access token for demonstration) at `http://localhost:3000/profile`.
+*   **API Route:** The NextAuth.js OIDC handler is located at `my-next-app/src/app/api/auth/[...nextauth]/route.ts`.
+
+### Important Notes for OIDC:
+
+*   **Environment Variables:** Ensure `OKTA_OIDC_CLIENT_ID`, `OKTA_OIDC_CLIENT_SECRET`, and `OKTA_OIDC_ISSUER` are correctly set in your environment.
+*   **NEXTAUTH_SECRET:** Always use a strong, random string for `NEXTAUTH_SECRET` in production.
+*   **HTTPS in Production:** For production deployments, ensure your `NEXTAUTH_URL` uses `https` and that your sign-in redirect URIs in Okta also use `https`.
+*   **Okta Configuration:** The exact steps for Okta setup might vary slightly based on your Okta organization type (e.g., developer vs. enterprise) and any updates to their interface. Refer to the official Okta documentation for the most current guidance.
+*   **Scopes:** By default, NextAuth.js requests `openid profile email` scopes. If you need additional scopes, you can configure them in the OktaProvider settings within `[...nextauth]/route.ts`.
+*   **Session Handling:** NextAuth.js handles session management. The example `SessionDisplay.tsx` component and `/profile` page (e.g., `http://localhost:3000/en/profile`) show how to access session data.
+
+---
+
+## SCIM 2.0 Endpoints (Stub Implementation)
+
+This application includes stub implementations for SCIM 2.0 User and Group provisioning endpoints. These are intended as a starting point for developing a full SCIM server.
+
+### Endpoints
+
+*   **Users:** `my-next-app/src/app/scim/v2/Users/[[...params]]/route.ts`
+    *   Handles requests to `/scim/v2/Users` and `/scim/v2/Users/{id}`.
+    *   Supports:
+        *   `GET /scim/v2/Users`: Lists users. Supports basic `userName eq` filtering.
+        *   `GET /scim/v2/Users/{id}`: Retrieves a user by ID.
+        *   `POST /scim/v2/Users`: Creates a new user. Checks for `userName` uniqueness.
+        *   `PUT /scim/v2/Users/{id}`: Updates a user by ID (full replace).
+        *   `PATCH /scim/v2/Users/{id}`: Partially updates a user. Stubbed for basic operations like modifying the `active` status.
+        *   `DELETE /scim/v2/Users/{id}`: Deletes a user by ID.
+*   **Groups:** `my-next-app/src/app/scim/v2/Groups/[[...params]]/route.ts`
+    *   Handles requests to `/scim/v2/Groups` and `/scim/v2/Groups/{id}`.
+    *   Supports:
+        *   `GET /scim/v2/Groups`: Lists groups. Supports basic `displayName eq` filtering.
+        *   `GET /scim/v2/Groups/{id}`: Retrieves a group by ID.
+        *   `POST /scim/v2/Groups`: Creates a new group. Checks for `displayName` uniqueness.
+        *   `PUT /scim/v2/Groups/{id}`: Updates a group by ID (full replace).
+        *   `PATCH /scim/v2/Groups/{id}`: Partially updates a group. Stubbed for basic member management and `displayName` changes.
+        *   `DELETE /scim/v2/Groups/{id}`: Deletes a group by ID.
+
+### Implementation Details
+
+*   **In-Memory Store:** The SCIM endpoints currently use a simple in-memory JavaScript object (`usersDB` and `groupsDB`) to store data. This data will be lost when the server restarts.
+*   **Stubbed Functionality:**
+    *   Many SCIM features like complex filtering, sorting, pagination (beyond basic totalResults), and comprehensive PATCH operations are only minimally implemented or return a `501 Not Implemented` status.
+    *   Error handling is basic.
+    *   Schema validation is minimal.
+*   **Authentication/Authorization:** These SCIM endpoints **do not currently implement any authentication or authorization**. In a production environment, you **MUST** secure these endpoints appropriately (e.g., using OAuth bearer tokens, API keys, or other standard mechanisms).
+*   **Logging:** Requests to these endpoints (method, path, body) are logged to the console.
+
+### Further Development
+
+To develop these into a production-ready SCIM server, you would need to:
+1.  Replace the in-memory store with a persistent database.
+2.  Implement robust authentication and authorization.
+3.  Fully implement SCIM schema validation, filtering, pagination, sorting, and complex PATCH operations.
+4.  Add comprehensive error handling and logging.
+5.  Consider rate limiting and other security best practices.
+
+---
+
+## SAML Metadata Test Script
+
+This project includes a basic test script to validate the SAML Service Provider (SP) metadata endpoint.
+
+### Running the SAML Metadata Test
+
+1.  **Ensure the development server is running** (see "General Setup").
+2.  **Run the test script from the root project directory:**
+    ```bash
+    npm run test:saml --prefix my-next-app
+    ```
+    Or, from the `my-next-app` directory:
+    ```bash
+    npm run test:saml
+    # or by directly executing: node test-saml.js
+    ```
+
+### What the SAML Test Validates
+
+The `test-saml.js` script performs the following checks on the `http://localhost:3000/api/auth/saml/metadata` endpoint:
+
+*   **Status Code:** Verifies that the endpoint returns a `200 OK` status.
+*   **Content-Type Header:** Checks if the `Content-Type` header is `application/xml` or `text/xml`.
+*   **Basic XML Content:** Confirms the presence of essential SAML metadata tags like `<md:EntityDescriptor>` (or `<EntityDescriptor>`) and `<md:SPSSODescriptor>` (or `<SPSSODescriptor>`) in the response body using simple string inclusion checks.
+
+### Limitations
+
+*   **No XML Schema Validation:** The script does not perform a full XML schema validation. It only checks for the presence of certain substrings.
+*   **No Cryptographic Validation:** It does not validate any signatures or encryption details within the metadata.
+*   **Does Not Test Assertion Flow:** This script **only** tests the metadata endpoint. It does not simulate a full SAML login flow, IdP interaction, or assertion consumption by the ACS endpoint.
+*   **Network Dependent:** Requires the Next.js development server to be running and accessible at `http://localhost:3000`.

--- a/my-next-app/package-lock.json
+++ b/my-next-app/package-lock.json
@@ -8,14 +8,17 @@
       "name": "my-next-app",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.39.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/material": "^7.1.0",
+        "express": "^5.1.0",
         "graphql": "^16.11.0",
         "graphql-request": "^7.2.0",
         "msw": "^2.8.7",
         "next": "15.3.3",
         "next-intl": "^4.1.0",
+        "passport-saml": "^3.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -54,6 +57,34 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.39.1.tgz",
+      "integrity": "sha512-McD8slui0oOA1pjR5sPjLPl5Zm//nLP/8T3kr8hxIsvNLvsiudYvPHhDFPjh1KcZ2nFxCkZmP6bRxaaPd/AnLA==",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1561,6 +1592,14 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -2441,6 +2480,27 @@
         "win32"
       ]
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2758,6 +2818,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2791,6 +2870,14 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2813,7 +2900,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2826,7 +2912,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2985,6 +3070,25 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -2996,6 +3100,14 @@
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/cosmiconfig": {
@@ -3150,6 +3262,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3184,7 +3304,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3194,11 +3313,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -3298,7 +3430,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3307,7 +3438,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3343,7 +3473,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3402,6 +3531,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3818,6 +3952,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3897,6 +4080,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -3952,6 +4151,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4001,7 +4216,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4025,7 +4239,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4107,7 +4320,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4198,7 +4410,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4245,6 +4456,32 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4278,6 +4515,11 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4301,6 +4543,14 @@
         "@formatjs/fast-memoize": "2.2.7",
         "@formatjs/icu-messageformat-parser": "2.11.2",
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4560,6 +4810,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4732,6 +4987,14 @@
       "dev": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -5130,9 +5393,27 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -5155,6 +5436,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5422,6 +5722,14 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.1.tgz",
+      "integrity": "sha512-txg/jZQwcbaF7PMJgY7aoxc9QuCxHVFMiEkDIJ60DwDz3PbtXPQnrzo+3X4IRYGChIwWLabRBRpf1k9hO9+xrQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5434,7 +5742,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5536,6 +5843,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5633,6 +5959,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/passport-saml": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/passport-saml/-/passport-saml-3.2.4.tgz",
+      "integrity": "sha512-JSgkFXeaexLNQh1RrOvJAgjLnZzH/S3HbX/mWAk+i7aulnjqUe7WKnPl1NPnJWqP7Dqsv0I2Xm6KIFHkftk0HA==",
+      "deprecated": "For versions >= 4, please use scopped package @node-saml/passport-saml",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.6",
+        "debug": "^4.3.2",
+        "passport-strategy": "^1.0.0",
+        "xml-crypto": "^2.1.3",
+        "xml-encryption": "^2.0.0",
+        "xml2js": "^0.4.23",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5723,6 +6083,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5742,6 +6119,18 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -5759,6 +6148,20 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/querystringify": {
@@ -5785,6 +6188,28 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -5926,6 +6351,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5968,6 +6416,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6001,6 +6468,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -6016,6 +6493,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/set-function-length": {
@@ -6063,6 +6575,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharp": {
       "version": "0.34.2",
@@ -6130,7 +6647,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -6149,7 +6665,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -6165,7 +6680,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6183,7 +6697,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6567,6 +7080,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -6631,6 +7152,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -6752,6 +7286,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.8.tgz",
@@ -6813,6 +7355,14 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/which": {
@@ -6935,6 +7485,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xml-crypto": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.6.tgz",
+      "integrity": "sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.9",
+        "xpath": "0.0.32"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xml-encryption": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.0",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/y18n": {

--- a/my-next-app/package.json
+++ b/my-next-app/package.json
@@ -6,17 +6,21 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:saml": "node test-saml.js"
   },
   "dependencies": {
+    "@auth/core": "^0.39.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.1.0",
+    "express": "^5.1.0",
     "graphql": "^16.11.0",
     "graphql-request": "^7.2.0",
     "msw": "^2.8.7",
     "next": "15.3.3",
     "next-intl": "^4.1.0",
+    "passport-saml": "^3.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/my-next-app/src/app/[locale]/layout.tsx
+++ b/my-next-app/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import ThemeRegistry from "../ThemeRegistry"; // MUI Theme Provider
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import MswDevProvider from '../MswDevProvider'; // Import MSW Provider
+import { SessionProvider } from "next-auth/react"; // Import SessionProvider
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -45,9 +46,11 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <MswDevProvider>
-          <NextIntlClientProvider locale={locale} messages={messages}>
-            <ThemeRegistry>{children}</ThemeRegistry>
-          </NextIntlClientProvider>
+          <SessionProvider> {/* SessionProvider wraps NextIntlClientProvider and ThemeRegistry */}
+            <NextIntlClientProvider locale={locale} messages={messages}>
+              <ThemeRegistry>{children}</ThemeRegistry>
+            </NextIntlClientProvider>
+          </SessionProvider>
         </MswDevProvider>
       </body>
     </html>

--- a/my-next-app/src/app/api/auth/[...nextauth]/route.ts
+++ b/my-next-app/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,44 @@
+import NextAuth from 'next-auth';
+import OktaProvider from 'next-auth/providers/okta';
+
+export const authOptions = {
+  providers: [
+    OktaProvider({
+      clientId: process.env.OKTA_OIDC_CLIENT_ID as string,
+      clientSecret: process.env.OKTA_OIDC_CLIENT_SECRET as string,
+      issuer: process.env.OKTA_OIDC_ISSUER as string,
+      // Ensure the authorization server is correctly configured in Okta
+      // and the issuer URL points to it.
+      // Example issuer: https://your-okta-domain.okta.com/oauth2/default
+    }),
+    // Add other providers here if needed
+  ],
+  callbacks: {
+    async jwt({ token, account }: { token: any; account: any }) {
+      // Persist the OAuth access_token to the token right after signin
+      if (account) {
+        token.accessToken = account.access_token;
+        token.idToken = account.id_token; // Persist the ID token
+      }
+      return token;
+    },
+    async session({ session, token }: { session: any; token: any }) {
+      // Send properties to the client, like an access_token and id_token from JWT
+      session.accessToken = token.accessToken;
+      session.idToken = token.idToken; // Add ID token to session
+      session.user.id = token.sub; // Add user ID (subject) to session user object
+      return session;
+    },
+  },
+  // Enable debug messages in the console if you are having problems
+  debug: process.env.NODE_ENV === 'development',
+  secret: process.env.NEXTAUTH_SECRET, // A random string used to hash tokens, sign cookies and generate cryptographic keys.
+  // pages: { // Optional: Customize NextAuth.js pages
+  //   signIn: '/login/oidc', // Redirect users to this page for sign-in
+  //   // error: '/auth/error', // Error code passed in query string as ?error=
+  // },
+};
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/my-next-app/src/app/api/auth/saml/login/route.ts
+++ b/my-next-app/src/app/api/auth/saml/login/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import passport from 'passport';
+import { Strategy as SamlStrategy } from 'passport-saml';
+
+// This file handles the initiation of the SAML login flow.
+// It will redirect the user to the Identity Provider (IdP).
+
+// Make sure passport and the SAML strategy are initialized.
+// Ideally, this initialization is done in a central place.
+// For this example, we'll re-ensure it here, but in a larger app, refactor.
+
+if (!passport._strategy('saml')) {
+  console.log("Login route: SAML strategy not found, attempting to initialize.");
+  // Placeholder for IdP public certificate - replace with actual certificate
+  const idpCert = `-----BEGIN CERTIFICATE-----
+REPLACE_WITH_IDP_PUBLIC_CERTIFICATE
+-----END CERTIFICATE-----`;
+
+  // Placeholder for IdP entry point (login URL) - replace with actual URL
+  const idpEntryPoint = 'REPLACE_WITH_IDP_LOGIN_URL';
+  const idpIssuer = 'REPLACE_WITH_IDP_ISSUER_URL';
+
+
+  passport.use(
+    new SamlStrategy(
+      {
+        path: '/api/auth/saml', // ACS URL path
+        entryPoint: idpEntryPoint,
+        issuer: 'http://localhost:3000/api/auth/saml/metadata', // Our SP issuer
+        cert: idpCert, // IdP's public certificate
+        callbackUrl: 'http://localhost:3000/api/auth/saml', // ACS URL
+        // Other options like audience, privateKey for decryption (if needed)
+      },
+      (profile: any, done: any) => {
+        console.log('SAML Profile (from login route context, should not be called here):', profile);
+        return done(null, profile);
+      }
+    )
+  );
+  passport.initialize();
+  console.log("Login route: SAML strategy initialized.");
+} else {
+  console.log("Login route: SAML strategy already initialized.");
+}
+
+export async function GET(req: NextRequest) {
+  console.log("GET /api/auth/saml/login called");
+  return new Promise((resolve, reject) => {
+    // Adapt Express middleware to Next.js API Route
+    const mockRes = {
+      redirect: (url: string) => {
+        console.log(`Redirecting to IdP: ${url}`);
+        resolve(NextResponse.redirect(url));
+      },
+      setHeader: (name: string, value: string) => {
+        // NextResponse handles headers automatically in redirect
+      },
+      end: () => {
+        // Should not be called for a redirect
+        console.error("mockRes.end() called unexpectedly in SAML login initiation");
+        resolve(NextResponse.json({ error: "Login initiation failed" }, { status: 500 }));
+      },
+      status: (statusCode: number) => ({ // Added to handle potential errors from passport.authenticate
+        send: (body: any) => {
+            console.error("mockRes.status.send called in SAML login", body);
+            resolve(NextResponse.json(body, { status: statusCode }));
+        },
+        end: () => {
+            console.error("mockRes.status.end called in SAML login");
+            resolve(NextResponse.json({}, { status: statusCode }));
+        }
+      }),
+    };
+
+    // `passport.authenticate` when called for SAML without a request from IdP (i.e., not an ACS request)
+    // will generate the SAML AuthnRequest and redirect the user to the IdP.
+    try {
+      const authenticate = passport.authenticate('saml', {
+        session: false,
+        // Additional SAML options if needed for AuthnRequest, e.g.
+        // samlFallback: 'login-request', // Or other options
+        // forceAuthn: true, // If you want to force re-authentication
+      });
+
+      (authenticate as any)(req, mockRes, (err: any) => {
+        // This callback is typically for errors in the middleware chain itself,
+        // not for the redirect functionality.
+        if (err) {
+          console.error('Error during SAML authentication initiation:', err);
+          resolve(NextResponse.json({ error: 'SAML login initiation failed', details: err.message }, { status: 500 }));
+        } else {
+          // This part should ideally not be reached if a redirect occurs.
+          // If it is, it means passport.authenticate didn't redirect.
+          console.warn("/api/auth/saml/login: passport.authenticate finished without redirecting or erroring.");
+          resolve(NextResponse.json({ error: "SAML login did not initiate redirect as expected." }, { status: 500 }));
+        }
+      });
+    } catch (e) {
+      console.error("Exception when calling passport.authenticate for login:", e);
+      resolve(NextResponse.json({ error: "SAML login initiation exception", details: (e as Error).message }, { status: 500 }));
+    }
+  });
+}

--- a/my-next-app/src/app/api/auth/saml/metadata/route.ts
+++ b/my-next-app/src/app/api/auth/saml/metadata/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import passport from 'passport';
+import { Strategy as SamlStrategy } from 'passport-saml';
+
+// This file serves the Service Provider (SP) metadata XML.
+
+// Ensure passport and SAML strategy are initialized.
+// This configuration should be identical to the one used in ACS and Login routes.
+if (!passport._strategy('saml')) {
+  console.log("Metadata route: SAML strategy not found, attempting to initialize.");
+  const idpCert = `-----BEGIN CERTIFICATE-----
+REPLACE_WITH_IDP_PUBLIC_CERTIFICATE
+-----END CERTIFICATE-----`;
+  const idpEntryPoint = 'REPLACE_WITH_IDP_LOGIN_URL';
+  const idpIssuer = 'REPLACE_WITH_IDP_ISSUER_URL';
+
+  passport.use(
+    new SamlStrategy(
+      {
+        path: '/api/auth/saml', // ACS URL path where IdP sends assertions
+        entryPoint: idpEntryPoint, // IdP's SSO URL
+        issuer: 'http://localhost:3000/api/auth/saml/metadata', // Our SP's entity ID
+        cert: idpCert, // IdP's public signing certificate
+        callbackUrl: 'http://localhost:3000/api/auth/saml', // Full ACS URL
+        // decryptionPvk: "REPLACE_WITH_YOUR_SP_PRIVATE_KEY_FOR_DECRYPTION", // If you need to decrypt assertions
+        // privateKey: "REPLACE_WITH_YOUR_SP_PRIVATE_KEY_FOR_SIGNING_AUTHNREQUESTS", // If you sign AuthnRequests
+      },
+      (profile: any, done: any) => {
+        // This callback is for processing the SAML assertion, not directly used by metadata generation.
+        console.log('SAML Profile (from metadata route context, should not be called here):', profile);
+        return done(null, profile);
+      }
+    )
+  );
+  passport.initialize();
+  console.log("Metadata route: SAML strategy initialized.");
+} else {
+  console.log("Metadata route: SAML strategy already initialized.");
+}
+
+export async function GET(req: NextRequest) {
+  console.log("GET /api/auth/saml/metadata called");
+  const strategy = passport._strategy('saml') as SamlStrategy;
+  if (!strategy) {
+    console.error("SAML strategy not initialized when trying to generate metadata.");
+    return NextResponse.json({ error: 'SAML strategy not initialized' }, { status: 500 });
+  }
+
+  try {
+    // The generateServiceProviderMetadata method may require the decryption public cert
+    // and signing public cert if you've configured private keys for those operations.
+    // For this example, we assume no specific SP signing/decryption certs are passed here,
+    // meaning either they are not used or the strategy handles them internally if configured.
+    // If you use SP signing or encryption, you might need to pass:
+    // - strategy.generateServiceProviderMetadata(decryptionCert, signingCert)
+    //   where decryptionCert and signingCert are the public keys corresponding to
+    //   decryptionPvk and privateKey configured in the strategy.
+    // For now, passing null as per typical examples when these are not explicitly managed here.
+    // @ts-ignore // passport-saml types might not expose this directly or clearly
+    const metadata = strategy.generateServiceProviderMetadata(null, null);
+
+    return new NextResponse(metadata, {
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  } catch (error) {
+    console.error("Error generating SAML SP metadata:", error);
+    return NextResponse.json({ error: 'Failed to generate SAML metadata', details: (error as Error).message }, { status: 500 });
+  }
+}

--- a/my-next-app/src/app/api/auth/saml/route.ts
+++ b/my-next-app/src/app/api/auth/saml/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import passport from 'passport';
+import { Strategy as SamlStrategy } from 'passport-saml';
+
+// Placeholder for IdP public certificate - replace with actual certificate
+const idpCert = `-----BEGIN CERTIFICATE-----
+REPLACE_WITH_IDP_PUBLIC_CERTIFICATE
+-----END CERTIFICATE-----`;
+
+// Placeholder for IdP entry point (login URL) - replace with actual URL
+const idpEntryPoint = 'REPLACE_WITH_IDP_LOGIN_URL';
+const idpIssuer = 'REPLACE_WITH_IDP_ISSUER_URL';
+
+passport.use(
+  new SamlStrategy(
+    {
+      path: '/api/auth/saml',
+      entryPoint: idpEntryPoint,
+      issuer: 'http://localhost:3000/api/auth/saml/metadata', // Our SP issuer
+      cert: idpCert, // IdP's public certificate
+      callbackUrl: 'http://localhost:3000/api/auth/saml', // ACS URL
+      // Other options like audience, privateKey for decryption (if needed)
+    },
+    (profile: any, done: any) => {
+      // For now, log the user profile to the console
+      console.log('SAML Profile:', profile);
+      // In a real application, you would find or create a user based on the profile
+      return done(null, profile);
+    }
+  )
+);
+
+// Initialize passport (typically done once in your app setup)
+// For Next.js API routes, we might need to ensure it's initialized per request or globally.
+// This is a simplified example.
+// This file now ONLY handles the ACS POST request.
+// Metadata is served from /api/auth/saml/metadata/route.ts
+// Login initiation is handled by /api/auth/saml/login/route.ts
+
+if (!passport._strategy('saml')) {
+  console.log("ACS route: SAML strategy not found, attempting to initialize.");
+  // Avoid re-registering strategy if hot-reloading.
+  // Initialization logic should be consistent across all saml routes.
+  passport.use(
+    new SamlStrategy(
+      {
+        path: '/api/auth/saml', // This is the path this route handles for SAML assertions
+        entryPoint: idpEntryPoint, // Must be defined (even if placeholder)
+        issuer: 'http://localhost:3000/api/auth/saml/metadata',
+        cert: idpCert, // Must be defined (even if placeholder)
+        callbackUrl: 'http://localhost:3000/api/auth/saml',
+      },
+      (profile: any, done: any) => {
+        console.log('SAML Profile (ACS):', profile);
+        return done(null, profile);
+      }
+    )
+  );
+  passport.initialize();
+  console.log("ACS route: SAML strategy initialized.");
+} else {
+  console.log("ACS route: SAML strategy already initialized.");
+}
+
+
+export async function POST(req: NextRequest) {
+  // This is the Assertion Consumer Service (ACS) endpoint.
+  // It processes the SAML assertion sent by the IdP.
+  console.log("POST /api/auth/saml (ACS) called");
+
+  return new Promise((resolve, reject) => {
+    const mockRes = {
+      redirect: (url: string) => {
+        // ACS should not typically redirect, but handle the POST and respond.
+        console.warn(`ACS trying to redirect to ${url}, this is unusual.`);
+        resolve(NextResponse.redirect(url));
+      },
+      setHeader: (name: string, value: string) => { /* Next.js handles this in NextResponse */ },
+      status: (statusCode: number) => ({
+        send: (body: any) => resolve(NextResponse.json(body, { status: statusCode })),
+        end: () => resolve(NextResponse.json({}, { status: statusCode }))
+      }),
+      send: (body: any) => resolve(NextResponse.json(body)),
+      end: (data?: any) => {
+        // If passport calls res.end() without data, resolve with a success if no error.
+        // This path might be taken if the strategy handles the response itself.
+        console.log("ACS mockRes.end() called with data:", data);
+        resolve(NextResponse.json( data || { message: "SAML processing ended." }));
+      }
+    };
+
+    try {
+      const authenticate = passport.authenticate('saml', { session: false }, (err: any, user: any, info: any) => {
+        if (err) {
+          console.error('SAML Authentication Error (ACS):', err);
+          return resolve(NextResponse.json({ error: 'SAML Authentication Failed', details: err.message || (err.stack ? err.stack.split('\n')[0] : 'Unknown error') }, { status: 500 }));
+        }
+        if (!user) {
+          console.error('SAML Authentication Failed (ACS): No user profile returned.', info);
+          return resolve(NextResponse.json({ error: 'SAML Authentication Failed', details: info?.message || 'No user profile.' }, { status: 401 }));
+        }
+        console.log('SAML Authentication Successful (ACS), Profile:', user);
+        // In a real app, you'd establish a session (e.g., using cookies or a JWT)
+        // For now, just returning the user profile.
+        return resolve(NextResponse.json({ message: 'SAML Assertion Consumed Successfully', user }));
+      });
+
+      (authenticate as any)(req, mockRes, (errorFromMiddlewareNext: any) => {
+        if (errorFromMiddlewareNext) {
+          console.error("Error passed to 'next' function in passport.authenticate (ACS):", errorFromMiddlewareNext);
+          return resolve(NextResponse.json({ error: 'Internal Server Error during SAML processing', details: errorFromMiddlewareNext.message }, { status: 500 }));
+        }
+        // If 'next' is called without error, it might mean the response is already sent by the strategy
+        // or there's an issue. Given our mockRes, a response should have been resolved already.
+        console.log("'Next' callback in ACS reached without error, assuming response handled.");
+      });
+
+    } catch (e) {
+      console.error("Exception when calling passport.authenticate for ACS:", e);
+      resolve(NextResponse.json({ error: "SAML ACS processing exception", details: (e as Error).message }, { status: 500 }));
+    }
+  });
+}
+
+// Helper to ensure passport is initialized (though above check might be enough)
+// Redundant due to the check at the top of the file, but harmless.
+function ensurePassportInitialized() {
+  if (!passport._strategy('saml')) {
+    // This block should ideally not be reached if the top-level check works.
+    console.warn("ensurePassportInitialized called and strategy was not found - this might indicate an issue.");
+    passport.initialize();
+  }
+}
+
+// Call it once when the module loads, or ensure it's called before strategy use.
+ensurePassportInitialized();

--- a/my-next-app/src/app/components/SessionDisplay.tsx
+++ b/my-next-app/src/app/components/SessionDisplay.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+
+export default function SessionDisplay() {
+  const { data: session, status } = useSession();
+
+  if (status === "loading") {
+    return <p>Loading session information...</p>;
+  }
+
+  if (status === "unauthenticated") {
+    return <p>You are not authenticated. Please log in.</p>;
+  }
+
+  if (session) {
+    return (
+      <div>
+        <h2>Current Session Information</h2>
+        <p>
+          <strong>User:</strong> {session.user?.name || session.user?.email || "N/A"}
+        </p>
+        <p>
+          <strong>User ID (from token.sub):</strong> {session.user?.id || "N/A"}
+        </p>
+        <p>
+          <strong>Email:</strong> {session.user?.email || "N/A"}
+        </p>
+        <p>
+          <strong>Expires:</strong> {session.expires ? new Date(session.expires).toLocaleString() : "N/A"}
+        </p>
+        <h3>Tokens (for demonstration - handle with care):</h3>
+        <pre style={{ background: "#f0f0f0", padding: "10px", overflowX: "auto" }}>
+          {JSON.stringify({ accessToken: session.accessToken, idToken: session.idToken }, null, 2)}
+        </pre>
+        <details>
+          <summary>Full Session Object (for debugging)</summary>
+          <pre style={{ background: "#f0f0f0", padding: "10px", overflowX: "auto" }}>
+            {JSON.stringify(session, null, 2)}
+          </pre>
+        </details>
+      </div>
+    );
+  }
+
+  return <p>No active session.</p>;
+}

--- a/my-next-app/src/app/login/oidc/page.tsx
+++ b/my-next-app/src/app/login/oidc/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useSession, signIn, signOut } from "next-auth/react";
+import { useRouter } from 'next/navigation';
+
+export default function OidcLoginPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  if (status === "loading") {
+    return <p>Loading...</p>;
+  }
+
+  if (session) {
+    return (
+      <div>
+        <h1>OIDC Login</h1>
+        <p>Welcome, {session.user?.name || session.user?.email}!</p>
+        <p>You are already signed in.</p>
+        <button onClick={() => router.push('/profile')}>View Profile (Session)</button>
+        <br />
+        <button onClick={() => signOut()}>Sign out</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>OIDC Login</h1>
+      <p>You are not signed in.</p>
+      {/* Using "okta" as the provider ID, as configured in [...nextauth]/route.ts */}
+      <button onClick={() => signIn("okta")}>Sign in with Okta (OIDC)</button>
+    </div>
+  );
+}

--- a/my-next-app/src/app/login/saml/page.tsx
+++ b/my-next-app/src/app/login/saml/page.tsx
@@ -1,0 +1,31 @@
+"use client"; // Required for event handlers
+
+import { useRouter } from 'next/navigation';
+
+export default function SamlLoginPage() {
+  const router = useRouter();
+
+  const handleLogin = () => {
+    // This will redirect the user to the IdP.
+    // The SAML strategy configured on the server-side (/api/auth/saml)
+    // has an 'entryPoint' which is the IdP's login URL.
+    // Passport's authenticate middleware (when not handling a POST) will redirect.
+    // We need a way to trigger this redirection from the client.
+    // Typically, the server would handle the redirect when a protected route is accessed
+    // or a specific login URL is hit on the server that then calls passport.authenticate.
+
+    // For a client-initiated login, we can have a specific API route
+    // that calls passport.authenticate('saml') which then redirects.
+    // Let's assume we will create such a route e.g., /api/auth/saml/login
+
+    router.push('/api/auth/saml/login'); // This route will trigger SAML flow
+  };
+
+  return (
+    <div>
+      <h1>SAML Login</h1>
+      <p>Click the button below to log in via SAML.</p>
+      <button onClick={handleLogin}>Login with SAML</button>
+    </div>
+  );
+}

--- a/my-next-app/src/app/profile/page.tsx
+++ b/my-next-app/src/app/profile/page.tsx
@@ -1,0 +1,15 @@
+import SessionDisplay from "../components/SessionDisplay"; // Adjust path as needed
+import Link from 'next/link';
+
+export default function ProfilePage() {
+  return (
+    <div>
+      <h1>User Profile</h1>
+      <SessionDisplay />
+      <br />
+      <Link href="/">Go to Home</Link>
+      <br />
+      <Link href="/login/oidc">Go to OIDC Login Page</Link>
+    </div>
+  );
+}

--- a/my-next-app/src/app/scim/v2/Groups/[[...params]]/route.ts
+++ b/my-next-app/src/app/scim/v2/Groups/[[...params]]/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SCIM_GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group';
+const SCIM_LIST_RESPONSE_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse';
+
+// In-memory store for groups (for stubbing purposes)
+const groupsDB: any = {};
+let nextGroupId = 1;
+
+async function parseBody(req: NextRequest) {
+  try {
+    return await req.json();
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const groupId = params.params?.[0];
+  const queryParams = req.nextUrl.searchParams;
+  console.log(`SCIM Groups GET request: Path: ${req.nextUrl.pathname}, ID: ${groupId}, Query: ${queryParams}`);
+
+  if (groupId) {
+    // Get group by ID
+    const group = groupsDB[groupId];
+    if (group) {
+      console.log(`SCIM Groups GET: Found group ${groupId}`, group);
+      return NextResponse.json(group, { status: 200 });
+    } else {
+      console.log(`SCIM Groups GET: Group ${groupId} not found`);
+      return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group not found' }, { status: 404 });
+    }
+  } else {
+    // List groups
+    // Basic filtering support for displayName eq
+    const filter = queryParams.get('filter');
+    let resources = Object.values(groupsDB);
+
+    if (filter && filter.includes('displayName eq')) {
+        const displayNameToFilter = filter.split('displayName eq "')[1]?.slice(0, -1);
+        if (displayNameToFilter) {
+            resources = resources.filter((group: any) => group.displayName === displayNameToFilter);
+        }
+    }
+
+    console.log(`SCIM Groups GET: Listing groups. Count: ${resources.length}`);
+    return NextResponse.json({
+      schemas: [SCIM_LIST_RESPONSE_SCHEMA],
+      totalResults: resources.length,
+      startIndex: 1,
+      itemsPerPage: resources.length,
+      Resources: resources,
+    }, { status: 200 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const body = await parseBody(req);
+  console.log(`SCIM Groups POST request: Path: ${req.nextUrl.pathname}, Body:`, body);
+
+  if (!body || !body.displayName) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Missing displayName' }, { status: 400 });
+  }
+
+  const existingGroup = Object.values(groupsDB).find((g: any) => g.displayName === body.displayName);
+  if (existingGroup) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], scimType: "uniqueness", detail: 'Group with this displayName already exists' }, { status: 409 });
+  }
+
+  const newGroup = {
+    schemas: [SCIM_GROUP_SCHEMA],
+    id: String(nextGroupId++),
+    displayName: body.displayName,
+    members: body.members || [], // Validate member format if necessary
+    meta: {
+      resourceType: "Group",
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+      location: `/scim/v2/Groups/${nextGroupId - 1}`,
+    },
+  };
+  groupsDB[newGroup.id] = newGroup;
+
+  console.log("SCIM Groups POST: Created new group:", newGroup);
+  return NextResponse.json(newGroup, { status: 201, headers: { Location: newGroup.meta.location } });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const groupId = params.params?.[0];
+  const body = await parseBody(req);
+  console.log(`SCIM Groups PUT request: Path: ${req.nextUrl.pathname}, ID: ${groupId}, Body:`, body);
+
+  if (!groupId) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group ID missing in path' }, { status: 400 });
+  }
+   if (!body) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Request body is missing or invalid' }, { status: 400 });
+  }
+
+  let existingGroup = groupsDB[groupId];
+  if (!existingGroup) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group not found' }, { status: 404 });
+  }
+
+  // Simple full update - replace group object, keeping ID and meta
+  const updatedGroup = {
+    ...existingGroup,
+    ...body,
+    id: groupId, // Ensure ID is not changed
+    meta: {
+      ...existingGroup.meta,
+      lastModified: new Date().toISOString(),
+    },
+  };
+  groupsDB[groupId] = updatedGroup;
+
+  console.log("SCIM Groups PUT: Updated group:", updatedGroup);
+  return NextResponse.json(updatedGroup, { status: 200 });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { params?: string[] } }) {
+    const groupId = params.params?.[0];
+    const body = await parseBody(req);
+    console.log(`SCIM Groups PATCH request: Path: ${req.nextUrl.pathname}, ID: ${groupId}, Body:`, body);
+
+    if (!groupId) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group ID missing in path' }, { status: 400 });
+    }
+    if (!body || !body.Operations || !Array.isArray(body.Operations)) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Invalid PATCH request body' }, { status: 400 });
+    }
+
+    let group = groupsDB[groupId];
+    if (!group) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group not found' }, { status: 404 });
+    }
+
+    // Basic PATCH operations for members
+    // Example: { "op": "add", "path": "members", "value": [{"value": "userId1"}] }
+    // Example: { "op": "remove", "path": "members[value eq \"userId1\"]" }
+    // This is a very simplified stub. A full SCIM PATCH for groups is complex.
+    body.Operations.forEach((op: any) => {
+        if (op.op && typeof op.op === 'string') {
+            op.op = op.op.toLowerCase();
+        }
+
+        if (op.path === "members" || op.path?.startsWith("members[")) {
+            const membersValue = op.value; // Can be an array or single object
+
+            if (op.op === "add") {
+                if (Array.isArray(membersValue)) {
+                    membersValue.forEach(member => group.members.push(member));
+                } else if (membersValue) {
+                    group.members.push(membersValue);
+                }
+            } else if (op.op === "remove") {
+                if (op.path?.includes("[")) { // e.g. members[value eq "userId1"]
+                    const userIdToRemove = op.path.split('value eq "')[1]?.slice(0, -2);
+                    if (userIdToRemove) {
+                        group.members = group.members.filter((m: any) => m.value !== userIdToRemove);
+                    }
+                } else { // remove all members if no specific path
+                   // This case is not typical for specific member removal, usually for clearing all.
+                   // Or if op.value provides specific members to remove (more complex logic).
+                   // For a simple stub, we might ignore general "remove" on "members" path without specific value matching.
+                }
+            } else if (op.op === "replace") {
+                 // If path is "members", SCIM expects the entire members array to be replaced by op.value
+                 if (op.path === "members" && Array.isArray(op.value)) {
+                    group.members = op.value;
+                 }
+            }
+        }
+        // Add other operations like replacing displayName etc.
+        if (op.path === "displayName" && (op.op === "replace" || op.op === "add")) {
+            group.displayName = op.value;
+        }
+    });
+
+    group.meta.lastModified = new Date().toISOString();
+    groupsDB[groupId] = group;
+
+    console.log("SCIM Groups PATCH: Updated group:", group);
+    return NextResponse.json(group, { status: 200 });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const groupId = params.params?.[0];
+  console.log(`SCIM Groups DELETE request: Path: ${req.nextUrl.pathname}, ID: ${groupId}`);
+
+  if (!groupId) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group ID missing in path' }, { status: 400 });
+  }
+
+  if (groupsDB[groupId]) {
+    delete groupsDB[groupId];
+    console.log(`SCIM Groups DELETE: Deleted group ${groupId}`);
+    return new NextResponse(null, { status: 204 }); // No content
+  } else {
+    console.log(`SCIM Groups DELETE: Group ${groupId} not found`);
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Group not found' }, { status: 404 });
+  }
+}
+
+// Fallback for other methods
+export async function defaultHandler(req: NextRequest) {
+  console.warn(`SCIM Groups: Method ${req.method} not implemented for ${req.nextUrl.pathname}`);
+  return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: `Method ${req.method} not supported.` }, { status: 405 });
+}

--- a/my-next-app/src/app/scim/v2/Users/[[...params]]/route.ts
+++ b/my-next-app/src/app/scim/v2/Users/[[...params]]/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCIM_LIST_RESPONSE_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse';
+
+// In-memory store for users (for stubbing purposes)
+const usersDB: any = {};
+let nextUserId = 1;
+
+async function parseBody(req: NextRequest) {
+  try {
+    return await req.json();
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const userId = params.params?.[0];
+  const queryParams = req.nextUrl.searchParams;
+  console.log(`SCIM Users GET request: Path: ${req.nextUrl.pathname}, ID: ${userId}, Query: ${queryParams}`);
+
+  if (userId) {
+    // Get user by ID
+    const user = usersDB[userId];
+    if (user) {
+      console.log(`SCIM Users GET: Found user ${userId}`, user);
+      return NextResponse.json(user, { status: 200 });
+    } else {
+      console.log(`SCIM Users GET: User ${userId} not found`);
+      return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User not found' }, { status: 404 });
+    }
+  } else {
+    // List users
+    // Basic filtering support for userName eq (as per many IdP checks)
+    const filter = queryParams.get('filter');
+    let resources = Object.values(usersDB);
+
+    if (filter && filter.includes('userName eq')) {
+        const userNameToFilter = filter.split('userName eq "')[1]?.slice(0, -1);
+        if (userNameToFilter) {
+            resources = resources.filter((user: any) => user.userName === userNameToFilter);
+        }
+    }
+
+    console.log(`SCIM Users GET: Listing users. Count: ${resources.length}`);
+    return NextResponse.json({
+      schemas: [SCIM_LIST_RESPONSE_SCHEMA],
+      totalResults: resources.length,
+      startIndex: 1,
+      itemsPerPage: resources.length,
+      Resources: resources,
+    }, { status: 200 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const body = await parseBody(req);
+  console.log(`SCIM Users POST request: Path: ${req.nextUrl.pathname}, Body:`, body);
+
+  if (!body || !body.userName) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Missing userName' }, { status: 400 });
+  }
+
+  // Check if user already exists (based on userName for simplicity)
+  const existingUser = Object.values(usersDB).find((u: any) => u.userName === body.userName);
+  if (existingUser) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], scimType: "uniqueness", detail: 'User with this userName already exists' }, { status: 409 });
+  }
+
+  const newUser = {
+    schemas: [SCIM_USER_SCHEMA],
+    id: String(nextUserId++),
+    userName: body.userName,
+    name: body.name || { givenName: "Test", familyName: "User" },
+    emails: body.emails || [{ primary: true, value: `${body.userName}@example.com`, type: "work" }],
+    active: body.active !== undefined ? body.active : true,
+    meta: {
+      resourceType: "User",
+      created: new Date().toISOString(),
+      lastModified: new Date().toISOString(),
+      location: `/scim/v2/Users/${nextUserId -1}`,
+    },
+  };
+  usersDB[newUser.id] = newUser;
+
+  console.log("SCIM Users POST: Created new user:", newUser);
+  return NextResponse.json(newUser, { status: 201, headers: { Location: newUser.meta.location } });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const userId = params.params?.[0];
+  const body = await parseBody(req);
+  console.log(`SCIM Users PUT request: Path: ${req.nextUrl.pathname}, ID: ${userId}, Body:`, body);
+
+  if (!userId) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User ID missing in path' }, { status: 400 });
+  }
+  if (!body) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Request body is missing or invalid' }, { status: 400 });
+  }
+
+  let existingUser = usersDB[userId];
+  if (!existingUser) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User not found' }, { status: 404 });
+  }
+
+  // Simple full update - replace user object, keeping ID and meta
+  // A real implementation needs to handle partial updates (PATCH) and specific attribute replacements.
+  const updatedUser = {
+    ...existingUser, // Keep original ID, meta.created
+    ...body, // Apply updates from body
+    id: userId, // Ensure ID is not changed
+    meta: {
+      ...existingUser.meta,
+      lastModified: new Date().toISOString(),
+    },
+  };
+  usersDB[userId] = updatedUser;
+
+  console.log("SCIM Users PUT: Updated user:", updatedUser);
+  return NextResponse.json(updatedUser, { status: 200 });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { params?: string[] } }) {
+    const userId = params.params?.[0];
+    const body = await parseBody(req);
+    console.log(`SCIM Users PATCH request: Path: ${req.nextUrl.pathname}, ID: ${userId}, Body:`, body);
+
+    if (!userId) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User ID missing in path' }, { status: 400 });
+    }
+    if (!body || !body.Operations || !Array.isArray(body.Operations)) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'Invalid PATCH request body' }, { status: 400 });
+    }
+
+    let user = usersDB[userId];
+    if (!user) {
+        return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User not found' }, { status: 404 });
+    }
+
+    // Basic PATCH operations (add, replace, remove for 'active' and 'members')
+    // This is a very simplified stub. A full SCIM PATCH is complex.
+    body.Operations.forEach((op: any) => {
+        if (op.op && typeof op.op === 'string') {
+            op.op = op.op.toLowerCase();
+        }
+
+        // Example: Patching user's active status
+        // { "op": "Replace", "path": "active", "value": false }
+        // { "op": "Replace", "value": { "active": false } }
+        if (op.path === "active" || (op.path === undefined && op.value && op.value.active !== undefined)) {
+            const value = op.path === "active" ? op.value : op.value.active;
+            if (op.op === "replace" || op.op === "add") { // 'add' can act like 'replace' for single-value attributes
+                user.active = value;
+            }
+        }
+        // Add more operations here, e.g., for emails, name, etc.
+    });
+
+    user.meta.lastModified = new Date().toISOString();
+    usersDB[userId] = user;
+
+    console.log("SCIM Users PATCH: Updated user:", user);
+    return NextResponse.json(user, { status: 200 });
+}
+
+
+export async function DELETE(req: NextRequest, { params }: { params: { params?: string[] } }) {
+  const userId = params.params?.[0];
+  console.log(`SCIM Users DELETE request: Path: ${req.nextUrl.pathname}, ID: ${userId}`);
+
+  if (!userId) {
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User ID missing in path' }, { status: 400 });
+  }
+
+  if (usersDB[userId]) {
+    delete usersDB[userId];
+    console.log(`SCIM Users DELETE: Deleted user ${userId}`);
+    return new NextResponse(null, { status: 204 }); // No content
+  } else {
+    console.log(`SCIM Users DELETE: User ${userId} not found`);
+    return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: 'User not found' }, { status: 404 });
+  }
+}
+
+// Fallback for other methods
+export async function defaultHandler(req: NextRequest) {
+  console.warn(`SCIM Users: Method ${req.method} not implemented for ${req.nextUrl.pathname}`);
+  return NextResponse.json({ schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"], detail: `Method ${req.method} not supported.` }, { status: 405 });
+}

--- a/my-next-app/test-saml.js
+++ b/my-next-app/test-saml.js
@@ -1,0 +1,82 @@
+const http = require('http');
+
+const metadataUrl = 'http://localhost:3000/api/auth/saml/metadata';
+let testFailed = false;
+
+function reportResult(testName, success, message) {
+    if (success) {
+        console.log(`✅ PASSED: ${testName}`);
+    } else {
+        console.error(`❌ FAILED: ${testName} - ${message}`);
+        testFailed = true;
+    }
+}
+
+console.log(`Starting SAML metadata test against: ${metadataUrl}`);
+
+const req = http.get(metadataUrl, (res) => {
+    // 1. Validate status code
+    reportResult(
+        "Status code is 200",
+        res.statusCode === 200,
+        `Expected 200, got ${res.statusCode}`
+    );
+
+    // 2. Validate Content-Type header
+    const contentType = res.headers['content-type'];
+    const isValidContentType = contentType && (contentType.includes('application/xml') || contentType.includes('text/xml'));
+    reportResult(
+        "Content-Type header is application/xml or text/xml",
+        isValidContentType,
+        `Expected application/xml or text/xml, got ${contentType}`
+    );
+
+    let body = '';
+    res.on('data', (chunk) => {
+        body += chunk;
+    });
+
+    res.on('end', () => {
+        if (res.statusCode === 200) {
+            // 3. Validate XML content (basic checks)
+            const bodyContainsEntityDescriptor = body.includes('<md:EntityDescriptor') || body.includes('<EntityDescriptor');
+            reportResult(
+                "Response body contains <EntityDescriptor>",
+                bodyContainsEntityDescriptor,
+                "Missing <EntityDescriptor> tag in response body."
+            );
+
+            const bodyContainsSPSSODescriptor = body.includes('<md:SPSSODescriptor') || body.includes('<SPSSODescriptor');
+            reportResult(
+                "Response body contains <SPSSODescriptor>",
+                bodyContainsSPSSODescriptor,
+                "Missing <SPSSODescriptor> tag in response body."
+            );
+
+            // A more robust XML validation would require an XML parsing library,
+            // but for a basic test, string includes is a start.
+            if (!bodyContainsEntityDescriptor || !bodyContainsSPSSODescriptor) {
+                console.log("Full response body for inspection:\n", body.substring(0, 1000) + (body.length > 1000 ? "..." : ""));
+            }
+
+        } else {
+            console.error("Skipping content validation due to non-200 status code.");
+        }
+
+        if (testFailed) {
+            console.error("\nSAML Metadata Test Suite: At least one test FAILED.");
+            process.exit(1);
+        } else {
+            console.log("\nSAML Metadata Test Suite: All tests PASSED.");
+            process.exit(0);
+        }
+    });
+});
+
+req.on('error', (e) => {
+    console.error(`❌ FAILED: HTTP request failed - ${e.message}`);
+    console.error("Ensure the Next.js development server is running ('npm run dev' in 'my-next-app').");
+    process.exit(1);
+});
+
+req.end();


### PR DESCRIPTION
This commit introduces a Proof of Concept for SAML and OIDC Single Sign-On (SSO) and SCIM 2.0 provisioning endpoints.

Key Features:

1.  **SAML Authentication:**
    *   Integrated `passport-saml` for SAML 2.0 authentication.
    *   Includes SP metadata endpoint (`/api/auth/saml/metadata`), ACS endpoint (`/api/auth/saml`), and login initiation (`/api/auth/saml/login`).
    *   Example SAML IdP metadata and configuration placeholders are provided in the README.
    *   A basic SAML login page (`/login/saml`) is available.

2.  **OIDC Authentication:**
    *   Integrated `@auth/core` (NextAuth.js) for OIDC authentication using Okta as the example provider.
    *   NextAuth.js handler at `/api/auth/[...nextauth]`.
    *   Configuration relies on environment variables for OIDC client ID, secret, and issuer.
    *   A basic OIDC login page (`/login/oidc`) and profile page (`/profile`) to display session information are included.

3.  **SCIM 2.0 Endpoints (Stubs):**
    *   Stub implementations for SCIM 2.0 User (`/scim/v2/Users`) and Group (`/scim/v2/Groups`) endpoints.
    *   Supports basic CRUD operations (GET, POST, PUT, PATCH, DELETE) with an in-memory store.
    *   These endpoints are currently unauthenticated and serve as a basic PoC.

4.  **SAML Test Script:**
    *   Added an `npm run test:saml` script (`my-next-app/test-saml.js`) to validate the SP metadata endpoint.

5.  **Documentation:**
    *   Updated the main `README.md` with comprehensive instructions for:
        *   General project setup.
        *   Configuring Okta as an IdP for both SAML and OIDC.
        *   Setting up necessary environment variables.
        *   Running the SAML metadata test script.
        *   Details about the SCIM endpoint stubs.

This PoC provides a foundational structure for integrating SAML, OIDC, and SCIM functionalities into a Next.js application.